### PR TITLE
Allow merging into base branches other than master

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -102,7 +102,7 @@ function cloneAndMerge() {
   }
 
   execWrap('git clone '+jobInfo.base_url+' .'); // clone upstream
-  execWrap('git checkout master'); // ensure we're on master
+  execWrap('git checkout '+jobInfo.base_ref); // checkout the base ref in the pull request
   execWrap('git remote add requester '+jobInfo.head_url); // add pull requester's repo
   execWrap('git fetch requester '+jobInfo.head_ref); // fetch only PR branch
   execWrap('git branch PR '+jobInfo.head_sha); // this is so we can merge the given SHA below
@@ -130,7 +130,7 @@ for (key in jobInfo)
 
 // message()
 exports.message = function(msg) {
-  if (!msg) 
+  if (!msg)
     msg = '';
   console.log('!botio_message:'+msg);
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -83,7 +83,7 @@ function postComment(obj, callback) {
   obj.body = obj.body;
 
   request.post({
-    url: url, 
+    url: url,
     json: {
       body: '#### From: '+config.name+'\n\n'+
             '----\n\n'+
@@ -128,9 +128,9 @@ function runJob(jobInfo, callback) {
   debug('Running command line:', commandLine);
 
   var t0 = Date.now();
-  child.exec(commandLine, { 
+  child.exec(commandLine, {
     timeout: (config.script_timeout || 3600)*1000,
-    env: common.extend(process.env, { 
+    env: common.extend(process.env, {
       BOTIO_JOBINFO: JSON.stringify(jobInfo),
       BOTIO_MODULE: __dirname+'/module.js'
     }),
@@ -303,6 +303,7 @@ app.post('/', function(req, res) {
             public_dir: path.resolve(config.public_dir+'/'+id),
             public_url: 'http://'+config.host+':'+config.port+'/'+id,
             base_url: 'git://github.com/'+config.repo+'.git',
+            base_ref: pull.base.ref,
             head_url: pull.head.repo.git_url,
             head_ref: pull.head.ref,
             head_sha: pull.head.sha,


### PR DESCRIPTION
I needed this fix because we're currently doing work on two diverging branches in Butter. What this does is checkout the base ref noted in the pull request (ie `arturadib:master` for this pull request) and then merge the head ref (ie `jbuck:multiple-heads` for this pull request) into that base. So whether we do a pull request against Butter's `master` or `integration` branches, it'll just work.
